### PR TITLE
댓글 목록 조회에서 게시글 존재 유무 확인 여부를 확인하지 않았던 오류 수정 및 테스트 요청

### DIFF
--- a/services/commentService.js
+++ b/services/commentService.js
@@ -21,6 +21,10 @@ async function getComment(postId, params) {
     const { page = 0, pageSize = 10} = params;
     const limit = Number(pageSize);
     const offset = Number(page) * limit;
+    const existedPost = await postRepository.findById(postId);
+    if(!existedPost){
+        throw new NotFoundError("존재하지 않습니다");
+    }
     return await commentRepository.getComments(offset, limit, postId); 
 }
 

--- a/services/postService.js
+++ b/services/postService.js
@@ -3,7 +3,7 @@ import groupRepository from '../repositories/groupRepository.js';
 import {ForbiddenError, NotFoundError , UnauthorizedError} from '../config/error.js';
 
 async function createPost(groupId, post){
-    const newPost = await groupRepository.findById(groupId); 
+    const newPost = await groupRepository.findById(groupId);
     
     if (!newPost) {
         throw new NotFoundError('존재하지 않습니다');
@@ -11,8 +11,6 @@ async function createPost(groupId, post){
     if(newPost.password !== post.groupPassword){
         throw new ForbiddenError('비밀번호가 틀렸습니다');
     }
-    
-    console.log(post);
     const {postPassword, groupPassword, ...data} = post;
     data.password = postPassword;
     const createdPost = await postRepository.save(groupId, data);


### PR DESCRIPTION
## 요약
<br>특정 게시글이 없을 시 404 에러(assert error)가 발생하도록 수정 완료<br>

## 작업 내용
<br>commentService에서 getComment 함수 부분 로직 수정<br>

## 참고 사항

<br><br>

## 관련 이슈

- Close #26 

<br><br>
